### PR TITLE
Feature: better send

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -49,6 +49,16 @@ Router.prototype.getWorker = function (req) {
   req.address = segments.slice(0, workers.length)
   req.data = this.getWorkerData(segments, workers)
 
+  try {
+    if (req.data.startsWith('[[') && req.data.endsWith(']]')) {
+      req.data = new Buffer(req.data, 'base64').toString()
+      req.data = JSON.parse(req.data)
+    }
+  } catch (ex) {
+    // pershaps the decoded req.data wasn't JSON
+    // in which case req.data should just be the decoded primitive
+  }
+
   logger.info({ id: req.message }, 'Routing')
 
   return worker

--- a/lib/router.js
+++ b/lib/router.js
@@ -55,7 +55,7 @@ Router.prototype.getWorker = function (req) {
       req.data = JSON.parse(req.data)
     }
   } catch (ex) {
-    // pershaps the decoded req.data wasn't JSON
+    // perhaps the decoded req.data wasn't JSON
     // in which case req.data should just be the decoded primitive
   }
 

--- a/test/unit/router.js
+++ b/test/unit/router.js
@@ -57,5 +57,74 @@ describe('Router', function (done) {
       should.not.exist(worker)
       done()
     })
+
+    it('should not decode an unencapsulated primitive base64 message', function(done) {
+      config.set('workers.path', path.resolve(path.join(__dirname, '../workers')))
+
+      // hello world
+      // aGVsbG8gd29ybGQ=
+
+      var req = {
+        message: 'hello-world:aGVsbG8gd29ybGQ='
+      }
+
+      var router = new Router()
+      var worker = router.getWorker(req)
+      should.exist(req.data)
+      req.data.should.equal('aGVsbG8gd29ybGQ=')
+      done()
+    })
+
+    it('should unpack an encapsulated primitive base64 message', function(done) {
+      config.set('workers.path', path.resolve(path.join(__dirname, '../workers')))
+
+      // hello world
+      // aGVsbG8gd29ybGQ=
+
+      var req = {
+        message: 'hello-world:[[aGVsbG8gd29ybGQ=]]'
+      }
+
+      var router = new Router()
+      var worker = router.getWorker(req)
+      should.exist(req.data)
+      req.data.should.equal('hello world')
+      done()
+    })
+
+    it('should not decode an unencapsulated json base64 message', function(done) {
+      config.set('workers.path', path.resolve(path.join(__dirname, '../workers')))
+
+      // { "message": "hello world" }
+      // eyAibWVzc2FnZSI6ICJoZWxsbyB3b3JsZCIgfSA=
+
+      var req = {
+        message: 'hello-world:eyAibWVzc2FnZSI6ICJoZWxsbyB3b3JsZCIgfSA='
+      }
+
+      var router = new Router()
+      var worker = router.getWorker(req)
+      should.exist(req.data)
+      req.data.should.equal('eyAibWVzc2FnZSI6ICJoZWxsbyB3b3JsZCIgfSA=')
+      done()
+    })
+
+    it('should unpack an encapsulated primitive base64 message', function(done) {
+      config.set('workers.path', path.resolve(path.join(__dirname, '../workers')))
+
+      // { "message": "hello world" }
+      // eyAibWVzc2FnZSI6ICJoZWxsbyB3b3JsZCIgfSA=
+
+      var req = {
+        message: 'hello-world:[[eyAibWVzc2FnZSI6ICJoZWxsbyB3b3JsZCIgfSA=]]'
+      }
+
+      var router = new Router()
+      var worker = router.getWorker(req)
+      should.exist(req.data)
+      req.data.should.be.type('object')
+      req.data.should.have.property('message', 'hello world')
+      done()
+    })
   })
 })


### PR DESCRIPTION
Requires https://github.com/dadi/queue-wrapper/pull/5

This PR works hand-in-hand with the queue-wrapper PR above to allow objects to be sent and received by queue-wrapper/queue.

Where previously you would have to construct a string and send that using queue-wrapper's `send(message, done)`, you can now do `send(address, object, done)`. If done this way, queue-wrapper will pack the message for you, and queue will unpack it for you. The latter is what concerns this PR.