### PR TITLE
fix: config changes

### DIFF
--- a/config.js
+++ b/config.js
@@ -135,7 +135,6 @@ function loadConfig () {
   } finally {
     const env = conf.get('env')
     conf.loadFile('config/config.' + env + '.json')
-    conf.validate()
   }
 }
 

--- a/config.js
+++ b/config.js
@@ -14,8 +14,8 @@ const conf = convict({
   },
   queue: {
     host: {
-      doc: 'The queue server host IP',
-      format: 'ipaddress',
+      doc: 'The queue server hostname or IP',
+      format: '*',
       default: '127.0.0.1'
     },
     port: {

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ See the [Why do I need a task queue?](#why-do-i-need-a-task-queue) section for m
 ## Configuration
 
 * **queue**
-  * **host**: (*ipaddress; default = 127.0.0.1*) The queue server host IP
+  * **host**: (*string; default = 127.0.0.1*) The queue server hostname or IP
   * **port**: (*port; default = 6379*) The queue server port number
 * **broker**
   * **queue**: (*string; default = ''*) The queue name


### PR DESCRIPTION
This PR follows our other products in removing `conf.validate()` from the config so that custom values can be added to configuration files. It also removes IP address validation from the `queue.host` config variable so that hostnames can be used.

Closes #10 