### PR TITLE
feat: initialize queue with queue name + options

### DIFF
--- a/lib/broker.js
+++ b/lib/broker.js
@@ -138,7 +138,7 @@ Broker.prototype.processResponse = function (req, err) {
  */
 Broker.prototype.initialiseQueue = function (options) {
   /* istanbul ignore next */
-  return new Rsmq(options.queue)
+  return new Rsmq(options.broker.queue, options.queue)
 }
 
 /**


### PR DESCRIPTION
Closes #12 
Replaces #13 (already reviewed ✅ )

This PR initializes `Rsmq` with the queue name as well as the regular options. 