### PR TITLE
fix: pass correct options to initialiseQueue

### DIFF
--- a/lib/broker.js
+++ b/lib/broker.js
@@ -37,7 +37,7 @@ if (config.get('env') !== 'test') {
 const Broker = function (queueHandler) {
   this.opts = config.get('broker')
   this.queueHandler = queueHandler
-  this.rsmq = this.initialiseQueue(this.opts)
+  this.rsmq = this.initialiseQueue(config.get(''))
   this.throttle = this.initialiseThrottle(this.opts)
 
   // message received


### PR DESCRIPTION
currently the code passes the `broker` subobject, not the whole one as required.

suggest new patch version