### PR TITLE
fix: pass correct config options to broker queue init

### DIFF
--- a/lib/broker.js
+++ b/lib/broker.js
@@ -35,10 +35,11 @@ if (config.get('env') !== 'test') {
  * that can be called when a message is received
  */
 const Broker = function (queueHandler) {
-  this.opts = config.get('broker')
+  this.brokerOpts = config.get('broker')
+  this.queueOpts = config.get('queue')
   this.queueHandler = queueHandler
-  this.rsmq = this.initialiseQueue(this.opts)
-  this.throttle = this.initialiseThrottle(this.opts)
+  this.rsmq = this.initialiseQueue(this.brokerOpts, this.queueOpts)
+  this.throttle = this.initialiseThrottle(this.brokerOpts)
 
   // message received
   this.rsmq.on('message', (msg, next) => {
@@ -60,8 +61,8 @@ const Broker = function (queueHandler) {
         message: msg.message,
         address: [],
         data: null,
-        retries: this.opts.retries - msg.rc,
-        timeout: now + this.opts.timeout,
+        retries: this.brokerOpts.retries - msg.rc,
+        timeout: now + this.brokerOpts.timeout,
         age: now + msg.sent,
         sent: msg.sent
       }
@@ -136,9 +137,9 @@ Broker.prototype.processResponse = function (req, err) {
  * @param {object} options - the set of configuration options loaded from the configuration file
  * @returns {object} - the RSMQ instance
  */
-Broker.prototype.initialiseQueue = function (options) {
+Broker.prototype.initialiseQueue = function (brokerOpts, queueOpts) {
   /* istanbul ignore next */
-  return new Rsmq(options.broker.queue, options.queue)
+  return new Rsmq(brokerOpts.queue, queueOpts)
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1989,6 +1989,12 @@
         "is-property": "1.0.2"
       }
     },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "dev": true
+    },
     "get-pkg-repo": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
@@ -3731,6 +3737,15 @@
             "has-flag": "1.0.0"
           }
         }
+      }
+    },
+    "mock-require": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-3.0.1.tgz",
+      "integrity": "sha1-1e/YNMDaDOxzx7Z3Y9gWfTLYUd4=",
+      "dev": true,
+      "requires": {
+        "get-caller-file": "1.0.2"
       }
     },
     "modify-values": {

--- a/package.json
+++ b/package.json
@@ -25,13 +25,14 @@
     "istanbul": "^1.1.0-alpha.1",
     "istanbul-cobertura-badger": "^1.2.1",
     "mocha": "^3.2.0",
+    "mock-require": "^3.0.1",
     "redis": "^2.6.4",
+    "semantic-release": "8.2.0",
     "should": "^11.1.2",
     "sinon": "^2.0.0",
     "snazzy": "^5.0.0",
     "standard": "^8.6.0",
-    "supertest": "^2.0.1",
-    "semantic-release": "8.2.0"
+    "supertest": "^2.0.1"
   },
   "repository": {
     "type": "git",

--- a/test/unit/broker.js
+++ b/test/unit/broker.js
@@ -3,6 +3,7 @@ var should = require('should')
 var sinon = require('sinon')
 var util = require('util')
 var EventEmitter = require('events')
+var mock = require('mock-require')
 
 var config = require(path.join(__dirname, '../../config'))
 var Broker = require(path.join(__dirname, '../../lib/broker'))
@@ -12,7 +13,7 @@ var QueueHandler = require(path.join(__dirname, '../../lib/queue-handler'))
 
 var FakeRsmq = function() {
   this.del = function() {
-    
+
   }
 
   this.start = function() {
@@ -30,556 +31,579 @@ var queueHandler
 util.inherits(FakeRsmq, EventEmitter)
 
 describe('Broker', function (done) {
-  beforeEach(function (done) {
-    config.set('workers.path', path.resolve(path.join(__dirname, '../workers')))
+  describe('with fake initialiseQueue', function(done) {
+    beforeEach(function (done) {
+      config.set('workers.path', path.resolve(path.join(__dirname, '../workers')))
 
-    fakeRsmq = new FakeRsmq()
-    sinon.stub(Broker.prototype, 'initialiseQueue').returns(fakeRsmq)
+      fakeRsmq = new FakeRsmq()
+      sinon.stub(Broker.prototype, 'initialiseQueue').returns(fakeRsmq)
 
-    done()
+      done()
+    })
+
+    afterEach(function (done) {
+      Broker.prototype.initialiseQueue.restore()
+      done()
+    })
+
+    describe('Worker', function () {
+      it('should receive additional data passed in the message request', function (done) {
+        queueHandler = new QueueHandler()
+
+        var msg = {
+          message: 'sms:send-reminder:123456',
+          address: 'hello',
+          sent: Date.now(),
+          rc: 1
+        }
+
+        var spy = sinon.spy(Router.prototype, 'getWorkerData')
+
+        fakeRsmq.emit('data', msg)
+
+        spy.restore()
+        spy.called.should.eql(true)
+        var returnValue = spy.firstCall.returnValue
+        returnValue.should.eql('123456')
+        done()
+      })
+    })
+
+    describe('Queue', function () {
+      it('should be started by throttle', function(done) {
+        var msg = {
+          message: 'XXX',
+          address: 'hello',
+          sent: Date.now(),
+          rc: 1
+        }
+
+        var queueHandler = new QueueHandler()
+
+        var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
+          if (typeof done === 'function') {
+            req.address = 'hello'
+            done()
+          }
+        })
+
+        var spy = sinon.spy(fakeRsmq, 'start')
+
+        // change the message count in the throttle
+        queueHandler.queue.throttle.workers.count = 5
+
+        fakeRsmq.emit('data', msg)
+
+        spy.restore()
+        handlerStub.restore()
+
+        spy.calledOnce.should.eql(true)
+        done()
+      })
+
+      it('should be stopped by throttle', function(done) {
+        var msg = {
+          message: 'XXX',
+          address: 'hello',
+          sent: Date.now(),
+          rc: 1
+        }
+
+        var queueHandler = new QueueHandler()
+
+        var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
+          if (typeof done === 'function') {
+            req.address = 'hello'
+            done()
+          }
+        })
+
+        var spy = sinon.spy(fakeRsmq, 'stop')
+
+        // change the message count in the throttle
+        queueHandler.queue.throttle.workers.count = 5
+
+        fakeRsmq.emit('message', msg, function() {
+
+        })
+
+        spy.restore()
+        handlerStub.restore()
+
+        spy.calledOnce.should.eql(true)
+        done()
+      })
+
+      it('should not throttle messages processed if limit is zero', function (done) {
+        var messagesProcessed = []
+        var queueHandler = new QueueHandler()
+        var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
+          if (typeof done === 'function') {
+            if (messagesProcessed.indexOf(req.message) === -1) {
+              messagesProcessed.push(req.message)
+            }
+            req.address = 'hello'
+            done()
+          }
+        })
+
+        queueHandler.queue.throttle.queue.value = 0
+
+        for (var i = 0; i < 5; i++) {
+          fakeRsmq.emit('data', {
+            message: 'MSG-' + i,
+            address: 'hello',
+            sent: Date.now(),
+            rc: 1
+          })
+        }
+
+        handlerStub.restore()
+        messagesProcessed.length.should.eql(5)
+
+        done()
+      })
+
+      it('should throttle messages processed if limit is exceeded', function (done) {
+        var messagesProcessed = []
+        var queueHandler = new QueueHandler()
+        var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
+          if (typeof done === 'function') {
+            if (messagesProcessed.indexOf(req.message) === -1) {
+              messagesProcessed.push(req.message)
+            }
+            req.address = 'hello'
+            done()
+          }
+        })
+
+        queueHandler.queue.throttle.queue.unit = 'minute'
+        queueHandler.queue.throttle.queue.value = 10
+
+        for (var i = 0; i < 20; i++) {
+          fakeRsmq.emit('data', {
+            message: 'MSG-' + i,
+            address: 'hello',
+            sent: Date.now(),
+            rc: 1
+          })
+        }
+
+        handlerStub.restore()
+        messagesProcessed.length.should.eql(10)
+
+        done()
+      })
+
+      it('should throttle messages processed over time', function (done) {
+        this.timeout(3000)
+
+        var emitCount = 0
+        var messagesProcessed = []
+        var queueHandler = new QueueHandler()
+        var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
+          if (typeof done === 'function') {
+            if (messagesProcessed.indexOf(req.message) === -1) {
+              messagesProcessed.push(req.message)
+            }
+            req.address = 'hello'
+            done()
+          }
+        })
+
+        queueHandler.queue.throttle.queue.unit = 'second'
+        queueHandler.queue.throttle.queue.value = 1
+
+        function emitAndWait() {
+          fakeRsmq.emit('data', {
+            message: 'MSG-' + emitCount,
+            address: 'hello',
+            sent: Date.now(),
+            rc: 1
+          })
+          emitCount++
+
+          if (emitCount < 10) {
+            setTimeout(emitAndWait, 250)
+          } else {
+            handlerStub.restore()
+            messagesProcessed.length.should.eql(3)
+            done()
+          }
+        }
+
+        emitAndWait()
+      })
+
+      it('should throttle specific messages processed if limit is exceeded', function (done) {
+        var messagesProcessed = []
+        var queueHandler = new QueueHandler()
+        var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
+          if (typeof done === 'function') {
+            if (messagesProcessed.indexOf(req.message) === -1) {
+              messagesProcessed.push(req.message)
+            }
+            req.address = 'hello'
+            done()
+          }
+        })
+
+        // add a message-specific limit of 5/second for
+        // messages beginning with "fps-"
+        queueHandler.queue.throttle.messages.push({
+          name: 'five-per-second',
+          regex: 'fps-.*',
+          regexOpts: 'i',
+          unit: 'second',
+          value: 5
+        })
+
+        // add a message-specific limit of 1/minute for
+        // messages beginning with "opm-"
+        queueHandler.queue.throttle.messages.push({
+          name: 'one-per-minute',
+          regex: 'opm-.*',
+          regexOpts: 'i',
+          unit: 'minute',
+          value: 1
+        })
+
+        // emit 10 messages starting with "fps-"
+        for (var i = 0; i < 10; i++) {
+          fakeRsmq.emit('data', {
+            message: 'fps-' + i,
+            address: 'hello',
+            sent: Date.now(),
+            rc: 1
+          })
+        }
+
+        // emit 5 messages starting with "ops-"
+        for (var i = 0; i < 5; i++) {
+          fakeRsmq.emit('data', {
+            message: 'opm-' + i,
+            address: 'hello',
+            sent: Date.now(),
+            rc: 1
+          })
+        }
+
+        handlerStub.restore()
+
+        // we should only see 6 – five for fps, and one for opm
+        messagesProcessed.length.should.eql(6)
+
+        done()
+      })
+
+      it('should discard throttled messages if discard is set to true', function (done) {
+        var messagesProcessed = []
+        var messagesDiscarded = []
+        var queueHandler = new QueueHandler()
+        var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
+          if (typeof done === 'function') {
+            if (messagesProcessed.indexOf(req.id) === -1) {
+              messagesProcessed.push(req.id)
+            }
+            req.address = 'hello'
+            done()
+          }
+        })
+
+        queueHandler.queue.rsmq.del = function (msgId) {
+          if (messagesProcessed.indexOf(msgId) === -1) {
+            messagesDiscarded.push(msgId)
+          }
+        }
+        queueHandler.queue.throttle.queue.unit = 'minute'
+        queueHandler.queue.throttle.queue.value = 1
+        queueHandler.queue.throttle.queue.discard = true
+
+        for (var i = 0; i < 5; i++) {
+          fakeRsmq.emit('data', {
+            id: 'MSG-' + i,
+            message: 'MSG-' + i,
+            address: 'hello',
+            sent: Date.now(),
+            rc: 1
+          })
+        }
+
+        handlerStub.restore()
+        messagesProcessed.length.should.eql(1)
+        messagesDiscarded.length.should.eql(4)
+
+        done()
+      })
+
+      it('should not discard throttled messages if discard is set to false', function (done) {
+        var messagesProcessed = []
+        var messagesDiscarded = []
+        var queueHandler = new QueueHandler()
+        var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
+          if (typeof done === 'function') {
+            if (messagesProcessed.indexOf(req.id) === -1) {
+              messagesProcessed.push(req.id)
+            }
+            req.address = 'hello'
+            done()
+          }
+        })
+
+        queueHandler.queue.rsmq.del = function (msgId) {
+          if (messagesProcessed.indexOf(msgId) === -1) {
+            messagesDiscarded.push(msgId)
+          }
+        }
+        queueHandler.queue.throttle.queue.unit = 'minute'
+        queueHandler.queue.throttle.queue.value = 1
+        queueHandler.queue.throttle.queue.discard = false
+
+        for (var i = 0; i < 5; i++) {
+          fakeRsmq.emit('data', {
+            id: 'MSG-' + i,
+            message: 'MSG-' + i,
+            address: 'hello',
+            sent: Date.now(),
+            rc: 1
+          })
+        }
+
+        handlerStub.restore()
+        messagesProcessed.length.should.eql(1)
+        messagesDiscarded.length.should.eql(0)
+
+        done()
+      })
+
+      it('should handle error events, passing the error to the QueueHandler', function(done) {
+        var msg = {
+          message: 'XXX'
+        }
+
+        var queueHandler = new QueueHandler()
+        var spy = sinon.spy(QueueHandler.prototype, 'handle')
+
+        fakeRsmq.emit('error', 'ERROR', msg)
+
+        spy.restore()
+
+        spy.calledOnce.should.eql(true)
+        var arg = spy.firstCall.args[0]
+        arg.name.should.eql('BrokerError')
+        arg.error.should.eql('ERROR')
+
+        done()
+      })
+
+      it('should handle data events, passing the message to the QueueHandler', function(done) {
+        var msg = {
+          message: 'XXX',
+          address: 'hello',
+          sent: Date.now(),
+          rc: 1
+        }
+
+        var queueHandler = new QueueHandler()
+        var spy = sinon.spy(QueueHandler.prototype, 'handle')
+
+        fakeRsmq.emit('data', msg)
+
+        spy.restore()
+
+        spy.called.should.eql(true)
+        var args = spy.firstCall.args
+        should.not.exist(args[0])
+        done()
+      })
+
+      it('should delete a message if it is processed successfully', function(done) {
+        var msg = {
+          id: 'hello',
+          message: 'XXX',
+          address: 'hello',
+          sent: Date.now(),
+          rc: 1
+        }
+
+        var queueHandler = new QueueHandler()
+
+        var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
+          if (typeof done === 'function') {
+            req.address = 'hello'
+            done()
+          }
+        })
+
+        var spy = sinon.spy(fakeRsmq, 'del')
+
+        fakeRsmq.emit('data', msg)
+
+        spy.restore()
+        handlerStub.restore()
+
+        spy.called.should.eql(true)
+        var args = spy.firstCall.args
+        args[0].should.eql(msg.id)
+        done()
+      })
+    })
+
+    describe('processResponse', function () {
+      it('should create a WorkerError when an error is returned by the QueueHandler', function (done) {
+        queueHandler = new QueueHandler()
+
+        var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
+          if (typeof done === 'function') {
+            req.address = 'hello'
+            done('ERROR')
+          }
+        })
+
+        var msg = {
+          message: 'XXX',
+          address: 'hello',
+          sent: Date.now(),
+          rc: 1
+        }
+
+        fakeRsmq.emit('data', msg)
+
+        handlerStub.restore()
+        handlerStub.calledTwice.should.eql(true)
+        var arg = handlerStub.secondCall.args[0]
+        arg.name.should.eql('WorkerError')
+        arg.error.should.eql('ERROR')
+        done()
+      })
+
+      it('should create an ExceededError when an error is returned by the QueueHandler and there are no retries left', function (done) {
+        queueHandler = new QueueHandler()
+
+        var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
+          if (typeof done === 'function') {
+            req.address = 'hello'
+            delete req.retries
+            done('ERROR')
+          }
+        })
+
+        var msg = {
+          message: 'XXX',
+          address: 'hello',
+          sent: Date.now(),
+          rc: 1
+        }
+
+        fakeRsmq.emit('data', msg)
+
+        handlerStub.restore()
+        handlerStub.calledTwice.should.eql(true)
+        var arg = handlerStub.secondCall.args[0]
+        arg.name.should.eql('ExceededError')
+        done()
+      })
+
+      it('should create an InvalidError when an returned message has no address', function (done) {
+        queueHandler = new QueueHandler()
+
+        var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
+          if (typeof done === 'function') {
+            req.address = []
+            done('ERROR')
+          }
+        })
+
+        var msg = {
+          message: 'XXX',
+          address: 'hello',
+          sent: Date.now(),
+          rc: 1
+        }
+
+        fakeRsmq.emit('data', msg)
+
+        handlerStub.restore()
+        handlerStub.calledTwice.should.eql(true)
+        var arg = handlerStub.secondCall.args[0]
+        arg.name.should.eql('InvalidError')
+        done()
+      })
+
+      it('should create a TimeoutError when a message timeout has passed', function (done) {
+        queueHandler = new QueueHandler()
+
+        var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
+          if (typeof done === 'function') {
+            req.address = 'hello'
+            req.timeout = 1000
+            done('ERROR')
+          }
+        })
+
+        var msg = {
+          message: 'XXX',
+          address: 'hello',
+          sent: Date.now(),
+          rc: 1
+        }
+
+        fakeRsmq.emit('data', msg)
+
+        handlerStub.restore()
+        handlerStub.calledTwice.should.eql(true)
+        var arg = handlerStub.secondCall.args[0]
+        arg.name.should.eql('TimeoutError')
+        done()
+      })
+
+      it('should return true if no error', function (done) {
+        queueHandler = new QueueHandler()
+
+        var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
+          if (typeof done === 'function') {
+            req.address = 'hello'
+            done()
+          }
+        })
+
+        var msg = {
+          message: 'XXX',
+          address: 'hello',
+          sent: Date.now(),
+          rc: 1
+        }
+
+        var spy = sinon.spy(Broker.prototype, 'processResponse')
+
+        fakeRsmq.emit('data', msg)
+
+        spy.restore()
+        spy.calledOnce.should.eql(true)
+        spy.firstCall.returnValue.should.eql(true)
+        done()
+      })
+    })
   })
 
-  afterEach(function (done) {
-    Broker.prototype.initialiseQueue.restore()
-    done()
-  })
-
-  describe('Worker', function () {
-    it('should receive additional data passed in the message request', function (done) {
-      queueHandler = new QueueHandler()
-
-      var msg = {
-        message: 'sms:send-reminder:123456',
-        address: 'hello',
-        sent: Date.now(),
-        rc: 1
-      }
-
-      var spy = sinon.spy(Router.prototype, 'getWorkerData')
-
-      fakeRsmq.emit('data', msg)
-
-      spy.restore()
-      spy.called.should.eql(true)
-      var returnValue = spy.firstCall.returnValue
-      returnValue.should.eql('123456')
-      done()
+  describe('initialiseQueue', function() {
+    var SpyRsmq = sinon.spy(FakeRsmq)
+    beforeEach(function() {
+      mock('rsmq-worker', SpyRsmq)
+      Broker = mock.reRequire(path.join(__dirname, '../../lib/broker'))
     })
-  })
-
-  describe('Queue', function () {
-    it('should be started by throttle', function(done) {
-      var msg = {
-        message: 'XXX',
-        address: 'hello',
-        sent: Date.now(),
-        rc: 1
-      }
-
-      var queueHandler = new QueueHandler()
-
-      var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
-        if (typeof done === 'function') {
-          req.address = 'hello'
-          done()
-        }
-      })
-
-      var spy = sinon.spy(fakeRsmq, 'start')
-
-      // change the message count in the throttle
-      queueHandler.queue.throttle.workers.count = 5
-
-      fakeRsmq.emit('data', msg)
-
-      spy.restore()
-      handlerStub.restore()
-
-      spy.calledOnce.should.eql(true)
-      done()
+    afterEach(function() {
+      mock.stopAll();
+      Broker = mock.reRequire(path.join(__dirname, '../../lib/broker'))
     })
-
-    it('should be stopped by throttle', function(done) {
-      var msg = {
-        message: 'XXX',
-        address: 'hello',
-        sent: Date.now(),
-        rc: 1
-      }
-
-      var queueHandler = new QueueHandler()
-
-      var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
-        if (typeof done === 'function') {
-          req.address = 'hello'
-          done()
-        }
-      })
-
-      var spy = sinon.spy(fakeRsmq, 'stop')
-
-      // change the message count in the throttle
-      queueHandler.queue.throttle.workers.count = 5
-
-      fakeRsmq.emit('message', msg, function() {
-
-      })
-
-      spy.restore()
-      handlerStub.restore()
-
-      spy.calledOnce.should.eql(true)
-      done()
-    })
-
-    it('should not throttle messages processed if limit is zero', function (done) {
-      var messagesProcessed = []
-      var queueHandler = new QueueHandler()
-      var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
-        if (typeof done === 'function') {
-          if (messagesProcessed.indexOf(req.message) === -1) {
-            messagesProcessed.push(req.message)
-          }
-          req.address = 'hello'
-          done()
-        }
-      })
-
-      queueHandler.queue.throttle.queue.value = 0
-
-      for (var i = 0; i < 5; i++) {
-        fakeRsmq.emit('data', {
-          message: 'MSG-' + i,
-          address: 'hello',
-          sent: Date.now(),
-          rc: 1
-        })
-      }
-
-      handlerStub.restore()
-      messagesProcessed.length.should.eql(5)
-
-      done()
-    })
-
-    it('should throttle messages processed if limit is exceeded', function (done) {
-      var messagesProcessed = []
-      var queueHandler = new QueueHandler()
-      var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
-        if (typeof done === 'function') {
-          if (messagesProcessed.indexOf(req.message) === -1) {
-            messagesProcessed.push(req.message)
-          }
-          req.address = 'hello'
-          done()
-        }
-      })
-
-      queueHandler.queue.throttle.queue.unit = 'minute'
-      queueHandler.queue.throttle.queue.value = 10
-
-      for (var i = 0; i < 20; i++) {
-        fakeRsmq.emit('data', {
-          message: 'MSG-' + i,
-          address: 'hello',
-          sent: Date.now(),
-          rc: 1
-        })
-      }
-
-      handlerStub.restore()
-      messagesProcessed.length.should.eql(10)
-
-      done()
-    })
-
-    it('should throttle messages processed over time', function (done) {
-      this.timeout(3000)
-
-      var emitCount = 0
-      var messagesProcessed = []
-      var queueHandler = new QueueHandler()
-      var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
-        if (typeof done === 'function') {
-          if (messagesProcessed.indexOf(req.message) === -1) {
-            messagesProcessed.push(req.message)
-          }
-          req.address = 'hello'
-          done()
-        }
-      })
-
-      queueHandler.queue.throttle.queue.unit = 'second'
-      queueHandler.queue.throttle.queue.value = 1
-
-      function emitAndWait() {
-        fakeRsmq.emit('data', {
-          message: 'MSG-' + emitCount,
-          address: 'hello',
-          sent: Date.now(),
-          rc: 1
-        })
-        emitCount++
-
-        if (emitCount < 10) {
-          setTimeout(emitAndWait, 250)
-        } else {
-          handlerStub.restore()
-          messagesProcessed.length.should.eql(3)
-          done()
-        }
-      }
-
-      emitAndWait()
-    })
-
-    it('should throttle specific messages processed if limit is exceeded', function (done) {
-      var messagesProcessed = []
-      var queueHandler = new QueueHandler()
-      var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
-        if (typeof done === 'function') {
-          if (messagesProcessed.indexOf(req.message) === -1) {
-            messagesProcessed.push(req.message)
-          }
-          req.address = 'hello'
-          done()
-        }
-      })
-
-      // add a message-specific limit of 5/second for
-      // messages beginning with "fps-"
-      queueHandler.queue.throttle.messages.push({
-        name: 'five-per-second',
-        regex: 'fps-.*',
-        regexOpts: 'i',
-        unit: 'second',
-        value: 5
-      })
-
-      // add a message-specific limit of 1/minute for
-      // messages beginning with "opm-"
-      queueHandler.queue.throttle.messages.push({
-        name: 'one-per-minute',
-        regex: 'opm-.*',
-        regexOpts: 'i',
-        unit: 'minute',
-        value: 1
-      })
-
-      // emit 10 messages starting with "fps-"
-      for (var i = 0; i < 10; i++) {
-        fakeRsmq.emit('data', {
-          message: 'fps-' + i,
-          address: 'hello',
-          sent: Date.now(),
-          rc: 1
-        })
-      }
-
-      // emit 5 messages starting with "ops-"
-      for (var i = 0; i < 5; i++) {
-        fakeRsmq.emit('data', {
-          message: 'opm-' + i,
-          address: 'hello',
-          sent: Date.now(),
-          rc: 1
-        })
-      }
-
-      handlerStub.restore()
-
-      // we should only see 6 – five for fps, and one for opm
-      messagesProcessed.length.should.eql(6)
-
-      done()
-    })
-
-    it('should discard throttled messages if discard is set to true', function (done) {
-      var messagesProcessed = []
-      var messagesDiscarded = []
-      var queueHandler = new QueueHandler()
-      var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
-        if (typeof done === 'function') {
-          if (messagesProcessed.indexOf(req.id) === -1) {
-            messagesProcessed.push(req.id)
-          }
-          req.address = 'hello'
-          done()
-        }
-      })
-
-      queueHandler.queue.rsmq.del = function (msgId) {
-        if (messagesProcessed.indexOf(msgId) === -1) {
-          messagesDiscarded.push(msgId)
-        }
-      }
-      queueHandler.queue.throttle.queue.unit = 'minute'
-      queueHandler.queue.throttle.queue.value = 1
-      queueHandler.queue.throttle.queue.discard = true
-
-      for (var i = 0; i < 5; i++) {
-        fakeRsmq.emit('data', {
-          id: 'MSG-' + i,
-          message: 'MSG-' + i,
-          address: 'hello',
-          sent: Date.now(),
-          rc: 1
-        })
-      }
-
-      handlerStub.restore()
-      messagesProcessed.length.should.eql(1)
-      messagesDiscarded.length.should.eql(4)
-
-      done()
-    })
-    
-    it('should not discard throttled messages if discard is set to false', function (done) {
-      var messagesProcessed = []
-      var messagesDiscarded = []
-      var queueHandler = new QueueHandler()
-      var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
-        if (typeof done === 'function') {
-          if (messagesProcessed.indexOf(req.id) === -1) {
-            messagesProcessed.push(req.id)
-          }
-          req.address = 'hello'
-          done()
-        }
-      })
-
-      queueHandler.queue.rsmq.del = function (msgId) {
-        if (messagesProcessed.indexOf(msgId) === -1) {
-          messagesDiscarded.push(msgId)
-        }
-      }
-      queueHandler.queue.throttle.queue.unit = 'minute'
-      queueHandler.queue.throttle.queue.value = 1
-      queueHandler.queue.throttle.queue.discard = false
-
-      for (var i = 0; i < 5; i++) {
-        fakeRsmq.emit('data', {
-          id: 'MSG-' + i,
-          message: 'MSG-' + i,
-          address: 'hello',
-          sent: Date.now(),
-          rc: 1
-        })
-      }
-
-      handlerStub.restore()
-      messagesProcessed.length.should.eql(1)
-      messagesDiscarded.length.should.eql(0)
-
-      done()
-    })
-    
-    it('should handle error events, passing the error to the QueueHandler', function(done) {
-      var msg = {
-        message: 'XXX'
-      }
-
-      var queueHandler = new QueueHandler()
-      var spy = sinon.spy(QueueHandler.prototype, 'handle')
-
-      fakeRsmq.emit('error', 'ERROR', msg)
-
-      spy.restore()
-
-      spy.calledOnce.should.eql(true)
-      var arg = spy.firstCall.args[0]
-      arg.name.should.eql('BrokerError')
-      arg.error.should.eql('ERROR')
-
-      done()
-    })
-
-    it('should handle data events, passing the message to the QueueHandler', function(done) {
-      var msg = {
-        message: 'XXX',
-        address: 'hello',
-        sent: Date.now(),
-        rc: 1
-      }
-
-      var queueHandler = new QueueHandler()
-      var spy = sinon.spy(QueueHandler.prototype, 'handle')
-
-      fakeRsmq.emit('data', msg)
-
-      spy.restore()
-
-      spy.called.should.eql(true)
-      var args = spy.firstCall.args
-      should.not.exist(args[0])
-      done()
-    })
-
-    it('should delete a message if it is processed successfully', function(done) {
-      var msg = {
-        id: 'hello',
-        message: 'XXX',
-        address: 'hello',
-        sent: Date.now(),
-        rc: 1
-      }
-
-      var queueHandler = new QueueHandler()
-
-      var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
-        if (typeof done === 'function') {
-          req.address = 'hello'
-          done()
-        }
-      })
-
-      var spy = sinon.spy(fakeRsmq, 'del')
-
-      fakeRsmq.emit('data', msg)
-
-      spy.restore()
-      handlerStub.restore()
-
-      spy.called.should.eql(true)
-      var args = spy.firstCall.args
-      args[0].should.eql(msg.id)
-      done()
-    })
-  })
-
-  describe('processResponse', function () {
-    it('should create a WorkerError when an error is returned by the QueueHandler', function (done) {
-      queueHandler = new QueueHandler()
-
-      var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
-        if (typeof done === 'function') {
-          req.address = 'hello'
-          done('ERROR')
-        }
-      })
-
-      var msg = {
-        message: 'XXX',
-        address: 'hello',
-        sent: Date.now(),
-        rc: 1
-      }
-
-      fakeRsmq.emit('data', msg)
-
-      handlerStub.restore()
-      handlerStub.calledTwice.should.eql(true)
-      var arg = handlerStub.secondCall.args[0]
-      arg.name.should.eql('WorkerError')
-      arg.error.should.eql('ERROR')
-      done()
-    })
-
-    it('should create an ExceededError when an error is returned by the QueueHandler and there are no retries left', function (done) {
-      queueHandler = new QueueHandler()
-
-      var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
-        if (typeof done === 'function') {
-          req.address = 'hello'
-          delete req.retries
-          done('ERROR')
-        }
-      })
-
-      var msg = {
-        message: 'XXX',
-        address: 'hello',
-        sent: Date.now(),
-        rc: 1
-      }
-
-      fakeRsmq.emit('data', msg)
-
-      handlerStub.restore()
-      handlerStub.calledTwice.should.eql(true)
-      var arg = handlerStub.secondCall.args[0]
-      arg.name.should.eql('ExceededError')
-      done()
-    })
-
-    it('should create an InvalidError when an returned message has no address', function (done) {
-      queueHandler = new QueueHandler()
-
-      var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
-        if (typeof done === 'function') {
-          req.address = []
-          done('ERROR')
-        }
-      })
-
-      var msg = {
-        message: 'XXX',
-        address: 'hello',
-        sent: Date.now(),
-        rc: 1
-      }
-
-      fakeRsmq.emit('data', msg)
-
-      handlerStub.restore()
-      handlerStub.calledTwice.should.eql(true)
-      var arg = handlerStub.secondCall.args[0]
-      arg.name.should.eql('InvalidError')
-      done()
-    })
-
-    it('should create a TimeoutError when a message timeout has passed', function (done) {
-      queueHandler = new QueueHandler()
-
-      var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
-        if (typeof done === 'function') {
-          req.address = 'hello'
-          req.timeout = 1000
-          done('ERROR')
-        }
-      })
-
-      var msg = {
-        message: 'XXX',
-        address: 'hello',
-        sent: Date.now(),
-        rc: 1
-      }
-
-      fakeRsmq.emit('data', msg)
-
-      handlerStub.restore()
-      handlerStub.calledTwice.should.eql(true)
-      var arg = handlerStub.secondCall.args[0]
-      arg.name.should.eql('TimeoutError')
-      done()
-    })
-
-    it('should return true if no error', function (done) {
-      queueHandler = new QueueHandler()
-
-      var handlerStub = sinon.stub(QueueHandler.prototype, 'handle').callsFake(function (err, req, done) {
-        if (typeof done === 'function') {
-          req.address = 'hello'
-          done()
-        }
-      })
-
-      var msg = {
-        message: 'XXX',
-        address: 'hello',
-        sent: Date.now(),
-        rc: 1
-      }
-
-      var spy = sinon.spy(Broker.prototype, 'processResponse')
-
-      fakeRsmq.emit('data', msg)
-
-      spy.restore()
-      spy.calledOnce.should.eql(true)
-      spy.firstCall.returnValue.should.eql(true)
-      done()
+    it('should call correctly', function() {
+      var mockQueueHandler = sinon.stub()
+      new Broker(mockQueueHandler)
+      sinon.assert.calledWith(
+        SpyRsmq,
+        config.get('broker').queue,
+        config.get('queue')
+      )
     })
   })
 })


### PR DESCRIPTION
This PR replaces #15 which fixes the incorrect options being passed to the broker initialiseQueue method.