### PR TITLE
Bump logger version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "dependencies": {
-    "@dadi/logger": "^1.0.1",
+    "@dadi/logger": "^1.3.0",
     "colors": "^1.1.2",
     "console-stamp": "^0.2.5",
     "convict": "^4.0.0",


### PR DESCRIPTION
Everything should be on 1.3.0

Fix #18