### PR TITLE
Reload workers on change

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -4,7 +4,6 @@
 
 'use strict'
 
-const config = require('../config')
 const logger = require('./logger')
 const Workers = require('./workers')
 
@@ -13,7 +12,7 @@ const Workers = require('./workers')
  * @classdesc Routes incoming messages to workers
  */
 const Router = function () {
-  this.workers = new Workers().load(config.get('workers.path'))
+  this.workerManager = new Workers()
 }
 
 /**
@@ -38,7 +37,7 @@ Router.prototype.route = function (req, queue, done) {
  */
 Router.prototype.getWorker = function (req) {
   const segments = req.message.split(':')
-  const workers = find(segments, this.workers)
+  const workers = find(segments, this.workerManager.getWorkers())
 
   const worker = workers.slice(-1)[0]
 
@@ -51,7 +50,7 @@ Router.prototype.getWorker = function (req) {
 
   try {
     if (req.data.startsWith('[[') && req.data.endsWith(']]')) {
-      req.data = new Buffer(req.data, 'base64').toString()
+      req.data = Buffer.from(req.data, 'base64').toString()
       req.data = JSON.parse(req.data)
     }
   } catch (ex) {

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -1,9 +1,20 @@
 'use strict'
 
+const chokidar = require('chokidar')
 const config = require('../config')
 const fs = require('fs')
 const mkdirp = require('mkdirp')
-const path = require('path')
+
+// Ensure the workers folder exists
+mkdirp(config.get('workers.path'), (err, made) => {
+  if (err) {
+    console.log(err)
+  }
+
+  if (made) {
+    console.log('\nCreated workers folder at ' + made + '\n')
+  }
+})
 
 /**
  * Workers
@@ -15,49 +26,51 @@ const path = require('path')
  */
 const Workers = function () {
   this.workers = {}
+  this.workerPath = config.get('workers.path')
 
-  // ensure the workers folder exists
-  mkdirp(config.get('workers.path'), (err, made) => {
-    if (err) {
-      console.log(err)
-    }
+  // Load all workers from the configured worker path
+  this.load(this.workerPath, this.workers)
 
-    if (made) {
-      console.log('\nCreated workers folder at ' + made + '\n')
+  // Start watching the worker path for new/changed files
+  const watcher = chokidar.watch(this.workerPath, {
+    ignored: /(^|[/\\])\../,
+    persistent: true
+  })
+
+  watcher.on('all', (event, path) => {
+    if (['add', 'change', 'unlink'].includes(event)) {
+      this.workers = {}
+      this.load(this.workerPath, this.workers)
     }
   })
 }
 
 /**
- * @param {string} root - xx
- * @returns {Array} workers - xx
+ * @param {string} path - the current worker path to process
+ * @param {Object} obj - the object to populate with worker functions
  */
-Workers.prototype.load = function (root) {
-  // files must be read before directories so that deeper levels can be
-  // assigned as properties to the initial worker functions
-  fs.readdirSync(root).forEach(fileName => this.loadPath(root, fileName, 'file'))
-  fs.readdirSync(root).forEach(fileName => this.loadPath(root, fileName, 'dir'))
+Workers.prototype.load = function (path, obj) {
+  const dir = fs.readdirSync(path)
 
-  return this.workers
+  for (var i = 0; i < dir.length; i++) {
+    const name = dir[i]
+    const target = path + '/' + name
+    const stats = fs.statSync(target)
+
+    if (stats.isFile()) {
+      if (name.slice(-3) === '.js') {
+        delete require.cache[target]
+        obj[name.slice(0, -3)] = require(target)
+      }
+    } else if (stats.isDirectory()) {
+      obj[name] = {}
+      this.load(target, obj[name])
+    }
+  }
 }
 
-/**
- * @param {string} root - xx
- * @param {string} fileName - xx
- * @param {string} type - xx
- */
-Workers.prototype.loadPath = function (root, fileName, type) {
-  const filePath = path.join(root, fileName)
-  const isDir = fs.lstatSync(filePath).isDirectory()
-  const basename = path.basename(filePath, '.js')
-
-  if (type === 'file' && path.extname(filePath) === '.js') {
-    this.workers[basename] = require(path.resolve(filePath))
-  }
-
-  if (type === 'dir' && isDir) { // recurse
-    this.workers[basename] = Object.assign(this.workers[basename] || {}, this.load(filePath))
-  }
+Workers.prototype.getWorkers = function () {
+  return this.workers
 }
 
 module.exports = function () {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@dadi/boot": "^1.1.4",
     "@dadi/logger": "^1.4.0",
+    "chokidar": "^3.0.0",
     "colors": "^1.1.2",
     "console-stamp": "^0.2.5",
     "convict": "^4.3.2",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -2,3 +2,4 @@
 --recursive
 --require=env-test
 --require test/pretest.js
+--exit


### PR DESCRIPTION
This PR introduces a filesystem watcher to reload workers when new js files are added to the workers directory, or existing workers are modified.

In addition, workers are loaded once only to accurately reflect the filesystem structure.

Close #32 
Fix #33 